### PR TITLE
Add role members validation to ensure a correct format used

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "members" {
   description = "(Optional) Identities that will be granted the privilege in role. Each entry can have one of the following values: 'user:{emailid}', 'serviceAccount:{emailid}', 'group:{emailid}', 'domain:{domain}'."
   type        = set(string)
   default     = []
+
+  validation {
+    condition     = alltrue([for m in var.members : can(regex("^(user|serviceAccount|group|domain):(.+)", m))])
+    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with a prefix such as e.g., `user:`, `serviceAccount:`, `group:` or `domain:`."
+  }
 }
 
 variable "authoritative" {


### PR DESCRIPTION
An IAM policy objects in Google Cloud consist of a list of role bindings,
and a particular role binding expects a list of principals (members) to
be provided.

When provided, the list of principals is to be specified using a special
format, where each principal is to be prefixed with a specific prefix
such as e.g., "user:", "group:", etc., depending on given principal
type.  Should this prefix be absent, then the Google API will return an
error resulting in Terraform run failure.

Thus, add validation of the "members" variable to ensure that each
principal given has a valid prefix set.

Signed-off-by: Krzysztof Wilczyński <kw@linux.com>