### PR TITLE
ignore_changes on etag value for google_project_iam_member

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,11 @@ resource "google_project_iam_member" "member" {
       description = try(condition.value.description, null)
     }
   }
+  lifecycle {
+    ignore_changes = [
+      etag
+    ]
+  }
 }
 
 resource "google_project_iam_policy" "policy" {


### PR DESCRIPTION
This value gets updated @ GCP in our environment when there are no changes being made to the project members, keys etc, so it results in changes to outputs in our terraform plans.

AFAICT this is not expected behavior from Google, ETAGs should remain constant, but that doesn't seem to be the reality.