### PR TITLE
feat: add federated principal support

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,12 @@ variable "role" {
 
 variable "members" {
   type        = set(string)
-  description = "(Optional) Identities that will be granted the privilege in role. Each entry can have one of the following values: 'user:{emailid}', 'serviceAccount:{emailid}', 'group:{emailid}', 'domain:{domain}'."
+  description = "(Optional) Identities that will be granted the privilege in role. Each entry can have one of the following values: 'user:{emailid}', 'serviceAccount:{emailid}', 'group:{emailid}', 'domain:{domain}' or using a federated principal."
   default     = []
 
   validation {
-    condition     = alltrue([for m in var.members : can(regex("^(user|serviceAccount|group|domain|computed):(.+)", m))])
-    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with a prefix such as e.g., `user:`, `serviceAccount:`, `group:`, `domain:` or `computed`."
+    condition     = alltrue([for m in var.members : can(regex("^(user|serviceAccount|group|domain|computed|principal|principalSet):(.+)", m))])
+    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with a prefix such as e.g., `user:`, `serviceAccount:`, `group:`, `domain:`, `computed:`, `principal:` or `principalSet:."
   }
 }
 


### PR DESCRIPTION
To use workload federation this validation needs to be extended;

[More information on federated principals](https://cloud.google.com/iam/docs/workload-identity-federation#principal-types)

It seems like this validation is the only part that was blocking.

Similar to https://github.com/mineiros-io/terraform-google-storage-bucket-iam/pull/21
